### PR TITLE
feat: Konfigurierbare Weiterleitungszeit für DSGVO-Disclaimer

### DIFF
--- a/includes/class-fundgrube-admin.php
+++ b/includes/class-fundgrube-admin.php
@@ -255,6 +255,14 @@ class Fundgrube_Admin {
             $this->settings_group,
             'fundgrube_privacy_section'
         );
+        
+        add_settings_field(
+            'redirect_delay',
+            __('Weiterleitungszeit (Sekunden)', 'fundgrube'),
+            array($this, 'redirect_delay_callback'),
+            $this->settings_group,
+            'fundgrube_privacy_section'
+        );
     }
     
     /**
@@ -349,6 +357,28 @@ class Fundgrube_Admin {
     }
     
     /**
+     * Callback für "Weiterleitungszeit"
+     * 
+     * @since 1.0.0
+     */
+    public function redirect_delay_callback() {
+        $options = get_option('fundgrube_options', array());
+        $value = isset($options['redirect_delay']) ? $options['redirect_delay'] : 5;
+        ?>
+        <input type="number" 
+               name="fundgrube_options[redirect_delay]" 
+               value="<?php echo esc_attr($value); ?>" 
+               min="1" 
+               max="30" 
+               class="small-text">
+        <label><?php _e('Sekunden', 'fundgrube'); ?></label>
+        <p class="description">
+            <?php _e('Zeit in Sekunden, die vor der automatischen Weiterleitung gewartet wird. Empfohlen: 3-10 Sekunden.', 'fundgrube'); ?>
+        </p>
+        <?php
+    }
+    
+    /**
      * Einstellungen validieren und bereinigen
      * 
      * @param array $input Eingabedaten
@@ -379,6 +409,13 @@ class Fundgrube_Admin {
             $sanitized['enable_redirect_disclaimer'] = (bool) $input['enable_redirect_disclaimer'];
         } else {
             $sanitized['enable_redirect_disclaimer'] = false;
+        }
+        
+        if (isset($input['redirect_delay'])) {
+            $sanitized['redirect_delay'] = absint($input['redirect_delay']);
+            if ($sanitized['redirect_delay'] < 1 || $sanitized['redirect_delay'] > 30) {
+                $sanitized['redirect_delay'] = 5;
+            }
         }
         
         return $sanitized;

--- a/includes/class-fundgrube-redirect.php
+++ b/includes/class-fundgrube-redirect.php
@@ -317,6 +317,17 @@ class Fundgrube_Redirect {
     }
     
     /**
+     * Konfigurierte Weiterleitungszeit abrufen
+     *
+     * @return int Weiterleitungszeit in Sekunden
+     * @since 1.0.0
+     */
+    public static function get_redirect_delay() {
+        $options = get_option('fundgrube_options', array());
+        return isset($options['redirect_delay']) ? absint($options['redirect_delay']) : 5;
+    }
+    
+    /**
      * Rewrite Rules neu laden
      *
      * @since 1.0.0

--- a/templates/redirect-disclaimer.php
+++ b/templates/redirect-disclaimer.php
@@ -19,6 +19,9 @@ $target_url = isset($_GET['url']) ? esc_url_raw(rawurldecode($_GET['url'])) : ''
 $service = isset($_GET['service']) ? sanitize_text_field($_GET['service']) : '';
 $item_title = isset($_GET['title']) ? sanitize_text_field(rawurldecode($_GET['title'])) : '';
 
+// Konfigurierte Weiterleitungszeit abrufen
+$redirect_delay = Fundgrube_Redirect::get_redirect_delay();
+
 // Validate URL
 if (empty($target_url) || !filter_var($target_url, FILTER_VALIDATE_URL)) {
     wp_redirect(home_url());
@@ -110,7 +113,7 @@ $service_info = $services[$service] ?? array(
                         <p>
                             <?php printf(
                                 __('Sie werden in <strong id="countdown">%d</strong> Sekunden zu %s weitergeleitet. Diese externe Website unterliegt nicht unserer Datenschutzerklärung.', 'fundgrube'),
-                                5,
+                                $redirect_delay,
                                 $service_info['name']
                             ); ?>
                         </p>
@@ -194,7 +197,7 @@ $service_info = $services[$service] ?? array(
         const progressBar = document.getElementById('progress-bar');
         const redirectButton = document.getElementById('redirect-now');
         
-        let timeLeft = 5;
+        let timeLeft = <?php echo intval($redirect_delay); ?>;
         let countdownInterval;
         let progressInterval;
         
@@ -215,8 +218,9 @@ $service_info = $services[$service] ?? array(
         // Progress Bar Animation
         function startProgress() {
             let progress = 0;
+            const increment = 100 / (timeLeft * 10); // 100% in der konfigurierten Zeit (10 Updates pro Sekunde)
             progressInterval = setInterval(function() {
-                progress += 2; // 100% in 5 Sekunden
+                progress += increment;
                 progressBar.style.width = progress + '%';
                 
                 if (progress >= 100) {
@@ -261,7 +265,7 @@ $service_info = $services[$service] ?? array(
         
         // Screen Reader Ankündigungen
         setTimeout(function() {
-            announcer.textContent = '<?php printf(__("Weiterleitung zu %s in 5 Sekunden. Drücken Sie Escape zum Abbrechen.", "fundgrube"), $service_info["name"]); ?>';
+            announcer.textContent = '<?php printf(__("Weiterleitung zu %s in %d Sekunden. Drücken Sie Escape zum Abbrechen.", "fundgrube"), $service_info["name"], $redirect_delay); ?>';
         }, 500);
         
     })();


### PR DESCRIPTION
- Neue Admin-Einstellung für Weiterleitungszeit (1-30 Sekunden)
- Standardwert: 5 Sekunden, empfohlen: 3-10 Sekunden
- Dynamische Anpassung von Countdown-Timer und Progress Bar
- Erweiterte Redirect-Klasse mit get_redirect_delay() Methode
- Barrierefreie Screen Reader Ankündigungen berücksichtigen konfigurierte Zeit
- Vollständige Integration in bestehende Datenschutz-Einstellungen